### PR TITLE
Video title clipping issue on video result page

### DIFF
--- a/frontend/src/components/SearchResultPageComponents/MatchedVideos.vue
+++ b/frontend/src/components/SearchResultPageComponents/MatchedVideos.vue
@@ -155,7 +155,7 @@ p {
   color: rgb(255, 99, 99);
   font-size: inherit;
   display: inline;
-  margin: 0 -5px;
+  margin: 0 -3.5px;
 }
 
 .titleText {
@@ -163,6 +163,7 @@ p {
   color: white;
   display: inline;
   font-size: small;
+  padding-left:4px;
 }
 
 /* .title p {
@@ -252,6 +253,7 @@ overflow: hidden;
 .view {
   display: grid;
   grid-template-columns: 14% auto; 
+    padding-left:3px;
 }
 
 .textInfo {


### PR DESCRIPTION
Issue is fixed.
Also added a tiny bit of spacing for the keyword cause it was colliding with the rest of the words in small screen 